### PR TITLE
260504-03: Refactor position classes to accept Redis key and position name in constructors

### DIFF
--- a/TubeTrack/include/AlignPosition.h
+++ b/TubeTrack/include/AlignPosition.h
@@ -4,13 +4,8 @@
 
 class CAlignPosition : public CPositionBase
 {
-
 public:
-    CAlignPosition() = default;
-    ~CAlignPosition() = default;
+    CAlignPosition(string redisKey, string positionName) : CPositionBase(redisKey, positionName) {}
 
     virtual void UpdateForm() override; // 刷新画面
-
-private:
-    const char *REDIS_KEY = "ALIGN_POS_TUBE_INFO"; // 发布的key名称
 };

--- a/TubeTrack/include/BackBuffer.h
+++ b/TubeTrack/include/BackBuffer.h
@@ -5,12 +5,8 @@
 class CBackBuffer : public CPositionBase
 {   
     public:
-        CBackBuffer() = default;
-        ~CBackBuffer() = default;
+        CBackBuffer(string redisKey, string positionName) : CPositionBase(redisKey, positionName) {}
 
         virtual void UpdateForm() override; // 刷新画面
         virtual void DebugOut() override;   // 输出缓冲区管子数量
-
-private:
-    const char *REDIS_KEY = "BACKBUFFER_POS_TUBE_INFO"; // 发布的key名称
 };

--- a/TubeTrack/include/Basket.h
+++ b/TubeTrack/include/Basket.h
@@ -5,12 +5,8 @@
 class CBasket : public CPositionBase
 {
 public:
-    CBasket() = default;
-    ~CBasket() = default;
+    CBasket(string redisKey, string positionName) : CPositionBase(redisKey, positionName) {}
 
     virtual void UpdateForm() override; // 刷新画面
     virtual void DebugOut() override;   // 输出成品料筐管子数量
-
-private:
-    const char *REDIS_KEY = "BASKET_POS_TUBE_INFO"; // 发布的key名称
 };

--- a/TubeTrack/include/CarvePosition.h
+++ b/TubeTrack/include/CarvePosition.h
@@ -5,11 +5,7 @@
 class CCarvePosition : public CPositionBase
 {
 public:
-    CCarvePosition() = default;
-    ~CCarvePosition() = default;
+    CCarvePosition(string redisKey, string positionName) : CPositionBase(redisKey, positionName) {}
 
     virtual void UpdateForm() override; // 刷新画面
-
-private:
-    const char *REDIS_KEY = "CARVE_POS_TUBE_INFO"; // 发布的key名称
 };

--- a/TubeTrack/include/CirclePosition.h
+++ b/TubeTrack/include/CirclePosition.h
@@ -5,11 +5,7 @@
 class CCirclePosition : public CPositionBase
 {
 public:
-    CCirclePosition() = default;
-    ~CCirclePosition() = default;
+    CCirclePosition(string redisKey, string positionName) : CPositionBase(redisKey, positionName) {}
 
     virtual void UpdateForm() override; // 刷新画面
-
-private:
-    const char *REDIS_KEY = "CIRCLE_POS_TUBE_INFO"; // 发布的key名称
 };

--- a/TubeTrack/include/PositionBase.h
+++ b/TubeTrack/include/PositionBase.h
@@ -1,7 +1,7 @@
 #pragma once
 #include "Tube.h"
 #include "../../include/usercmd.h"
-#indeque<unique_ptr<CTube>> m_tubes;clude <deque>
+#include <deque>
 #include <memory>
 #include <cstddef>
 using namespace std;
@@ -14,7 +14,7 @@ public:
 	CPositionBase();
 
 private:
-	
+	deque<unique_ptr<CTube>> m_tubes;
 	bool m_bOccupied;
 	bool m_bTriggerEnabled;
 	bool m_bUpdateTagEnabled;

--- a/TubeTrack/include/PositionBase.h
+++ b/TubeTrack/include/PositionBase.h
@@ -1,7 +1,7 @@
 #pragma once
 #include "Tube.h"
 #include "../../include/usercmd.h"
-#include <deque>
+#indeque<unique_ptr<CTube>> m_tubes;clude <deque>
 #include <memory>
 #include <cstddef>
 using namespace std;
@@ -14,7 +14,7 @@ public:
 	CPositionBase();
 
 private:
-	deque<unique_ptr<CTube>> m_tubes;
+	
 	bool m_bOccupied;
 	bool m_bTriggerEnabled;
 	bool m_bUpdateTagEnabled;

--- a/TubeTrack/include/PositionBase.h
+++ b/TubeTrack/include/PositionBase.h
@@ -11,13 +11,22 @@ struct TubeTrackContext; // 前向声明
 class CPositionBase
 {
 public:
-	CPositionBase();
+	CPositionBase(string redisKey, string positionName) : m_redisKey(redisKey), m_positionName(positionName)
+	{
+		m_bTriggerEnabled	= true;
+		m_bUpdateTagEnabled = true;
+		m_bWbReleased = true;
+	}
 
 private:
 	deque<unique_ptr<CTube>> m_tubes;
 	bool m_bOccupied;
 	bool m_bTriggerEnabled;
 	bool m_bUpdateTagEnabled;
+
+protected:
+	string m_redisKey; // Redis键名称
+	string m_positionName; // 工位名称（用于日志）
 
 protected:
 	TubeTrackContext* m_ctx = nullptr; // 上下文指针
@@ -45,7 +54,8 @@ public:
 	virtual bool Modify(const ModifyTubeCmd &cmd);
 	virtual bool Delete(int seqNo);
 	virtual void RestoreFromTag();
-	virtual bool RestoreFromJson(const string &jsonStr, const char *sourceName = nullptr);
+	virtual void RestoreFromRedis();
+	virtual void RestoreFromJson(const string &jsonStr);
 	virtual void UpdateForm(); // 刷新画面
 	virtual void EntryTriggerBeforePush(CTube &tube);
 	virtual void EntryTrigger(const CTube &tube);

--- a/TubeTrack/include/ProductionPlan.h
+++ b/TubeTrack/include/ProductionPlan.h
@@ -9,15 +9,19 @@ class CProductionPlan
 {
 private:
     TubeTrackContext* m_ctx = nullptr; // 上下文指针
+    string m_redisKey; // Redis键名称
+	string m_positionName; // 工位名称（用于日志）
     string convertToJson();
 
 public:
+    CProductionPlan(string redisKey, string positionName) : m_redisKey(redisKey), m_positionName(positionName) {}
     void SetContext(TubeTrackContext& ctx) { m_ctx = &ctx; }
     std::unique_ptr<CTube> Pop(int mode = 0);
     void UpdateForm();
     void Initialize();
     bool ApplyCurrentContract(const string &orderNo, const string &itemNo);
-    bool RestoreFromJson(const string &jsonStr);
+    void RestoreFromRedis();
+    void RestoreFromJson(const string &jsonStr);
     bool IsEmpty();
 
 private:
@@ -30,6 +34,4 @@ private:
     string meltno_coupling; // 接箍炉号
     int feed_num;           // 投料支数
     int tube_no;            // 管号
-
-    const char *REDIS_KEY = "PlanInfo"; // 发布的key名称
 };

--- a/TubeTrack/include/Scrapt.h
+++ b/TubeTrack/include/Scrapt.h
@@ -4,12 +4,9 @@
 
 class CScrapt : public CPositionBase
 {
-    public:
-    CScrapt() = default;
-    ~CScrapt() = default;
+public:
+    CScrapt(string redisKey, string positionName) : CPositionBase(redisKey, positionName) {}
 
     virtual void UpdateForm() override; // 刷新画面
-    virtual void DebugOut() override;   //输出废料筐管子数量
-    private:
-    const char *REDIS_KEY = "SCRAPT_POS_TUBE_INFO"; // 发布的key名称
+    virtual void DebugOut() override;   // 输出废料筐管子数量
 };

--- a/TubeTrack/include/ScraptRoller.h
+++ b/TubeTrack/include/ScraptRoller.h
@@ -4,12 +4,8 @@
 
 class CScraptRoller : public CPositionBase
 {
-    public:
-    CScraptRoller() = default;
-    ~CScraptRoller() = default;
+public:
+    CScraptRoller(string redisKey, string positionName) : CPositionBase(redisKey, positionName) {}
 
     virtual void UpdateForm() override; // 刷新画面
-
-    private:
-    const char *REDIS_KEY = "SCRAPTROLLER_POS_TUBE_INFO"; //
 };

--- a/TubeTrack/include/SprayPosition.h
+++ b/TubeTrack/include/SprayPosition.h
@@ -5,11 +5,7 @@
 class CSprayPosition : public CPositionBase
 {
 public:
-    CSprayPosition() = default;
-    ~CSprayPosition() = default;
+    CSprayPosition(string redisKey, string positionName) : CPositionBase(redisKey, positionName) {}
 
     virtual void UpdateForm() override; // 刷新画面
-
-private:
-    const char *REDIS_KEY = "SPRAY_POS_TUBE_INFO"; // 发布的key名称
 };

--- a/TubeTrack/include/TubeTrackContext.h
+++ b/TubeTrack/include/TubeTrackContext.h
@@ -54,44 +54,7 @@ struct TubeTrackContext {
         walkingBeam.SetContext(*this);
 
         // 从Redis恢复工位状态
-        // 1. 定义Lambda表达式（复用恢复逻辑）
-        // auto restorePosition = [this](CPositionBase &position, const char *redisKey, const char *positionName)
-        // {
-        //     if (!redis)
-        //     {
-        //         return false;
-        //     }
-        //     // 从Redis获取数据并恢复
-        //     auto value = redis->get(redisKey);
-        //     if (!value)
-        //     {
-        //         spdlog::info("Redis中未找到{}数据，初始化为空工位", positionName);
-        //         position.Clear();  // 确保为空
-        //         return true;  // 返回true表示正常状态
-        //     }
-        //     // 调用工位的恢复方法
-        //     return position.RestoreFromJson(*value, positionName);
-        // };
-
-        // 2. 恢复生产计划
-        prodPlan.RestoreFromRedis(); // 先尝试从Redis恢复生产计划
-        // bool planRestored = false;
-        // if (redis)
-        // {
-        //     // 从Redis获取生产计划数据并恢复
-        //     auto planValue = redis->get("PlanInfo");
-        //     if (planValue)
-        //     {
-        //         planRestored = prodPlan.RestoreFromJson(*planValue);
-        //     }
-        // }
-
-        // if (!planRestored)
-        // {
-        //     prodPlan.Initialize(); // 无Redis状态时回退到数据库初始化生产计划
-        // }
-
-        // 3. 恢复各个工位状态
+        prodPlan.RestoreFromRedis(); 
         alignPos.RestoreFromRedis();
         weightPos.RestoreFromRedis();   
         carvePos.RestoreFromRedis();
@@ -101,15 +64,7 @@ struct TubeTrackContext {
         backBuffer.RestoreFromRedis();
         scrapt.RestoreFromRedis();
         basket.RestoreFromRedis();
-        // restorePosition(alignPos, "ALIGN_POS_TUBE_INFO", "对齐工位");
-        // restorePosition(weightPos, "WEIGHT_POS_TUBE_INFO", "称重工位");
-        // restorePosition(carvePos, "CARVE_POS_TUBE_INFO", "刻印工位");
-        // restorePosition(sprayPos, "SPRAY_POS_TUBE_INFO", "喷印工位");
-        // restorePosition(circlePos, "CIRCLE_POS_TUBE_INFO", "色环工位");
-        // restorePosition(scraptRoller, "SCRAPTROLLER_POS_TUBE_INFO", "废料辊道");
-        // restorePosition(backBuffer, "BACKBUFFER_POS_TUBE_INFO", "缓冲区");
-        // restorePosition(scrapt, "SCRAPT_POS_TUBE_INFO", "废料筐");
-        // restorePosition(basket, "BASKET_POS_TUBE_INFO", "成品筐");
+
     }
 
     // 清理资源

--- a/TubeTrack/include/TubeTrackContext.h
+++ b/TubeTrack/include/TubeTrackContext.h
@@ -17,7 +17,7 @@
 #include <sw/redis++/redis++.h>
 #include <pqxx/pqxx>
 #include "logging.h"   // spdlog
-#include "../include/higplat.h"
+#include "higplat.h"
 #include <memory>
 
 struct TubeTrackContext {
@@ -27,17 +27,17 @@ struct TubeTrackContext {
     std::unique_ptr<pqxx::connection> pgConn;
 
     // 工位对象
-    CProductionPlan prodPlan;
-    CAlignPosition alignPos;
-    CCarvePosition  carvePos;
-    CWeightPosition weightPos;
-    CSprayPosition  sprayPos;
-    CCirclePosition circlePos;
-    CScraptRoller   scraptRoller;
-    CBackBuffer     backBuffer;
-    CScrapt         scrapt;
-    CBasket         basket;
-    WalkingBeam     walkingBeam;
+    CProductionPlan prodPlan{"PlanInfo", "生产计划工位"}; // 生产计划工位
+    CAlignPosition alignPos{"ALIGN_POS_TUBE_INFO", "对齐工位"}; // 对齐工位
+    CCarvePosition  carvePos{"CARVE_POS_TUBE_INFO", "刻印工位"}; // 刻印工位
+    CWeightPosition weightPos{"WEIGHT_POS_TUBE_INFO", "称重工位"}; // 称重工位
+    CSprayPosition  sprayPos{"SPRAY_POS_TUBE_INFO", "喷印工位"}; // 喷印工位
+    CCirclePosition circlePos{"CIRCLE_POS_TUBE_INFO", "色环工位"}; // 色环工位
+    CScraptRoller   scraptRoller{"SCRAPTROLLER_POS_TUBE_INFO", "废料辊道工位"}; // 废料辊道工位
+    CBackBuffer     backBuffer{"BACKBUFFER_POS_TUBE_INFO", "缓冲区工位"}; // 缓冲区工位
+    CScrapt         scrapt{"SCRAPT_POS_TUBE_INFO", "废料筐工位"}; // 废料筐工位
+    CBasket         basket{"BASKET_POS_TUBE_INFO", "成品筐工位"}; // 成品筐工位
+    WalkingBeam     walkingBeam; // 步进梁工位
 
     // 统一注入上下文到所有工位
     void Init() {
@@ -55,51 +55,61 @@ struct TubeTrackContext {
 
         // 从Redis恢复工位状态
         // 1. 定义Lambda表达式（复用恢复逻辑）
-        auto restorePosition = [this](CPositionBase &position, const char *redisKey, const char *positionName)
-        {
-            if (!redis)
-            {
-                return false;
-            }
-            // 从Redis获取数据并恢复
-            auto value = redis->get(redisKey);
-            if (!value)
-            {
-                spdlog::info("Redis中未找到{}数据，初始化为空工位", positionName);
-                position.Clear();  // 确保为空
-                return true;  // 返回true表示正常状态
-            }
-            // 调用工位的恢复方法
-            return position.RestoreFromJson(*value, positionName);
-        };
+        // auto restorePosition = [this](CPositionBase &position, const char *redisKey, const char *positionName)
+        // {
+        //     if (!redis)
+        //     {
+        //         return false;
+        //     }
+        //     // 从Redis获取数据并恢复
+        //     auto value = redis->get(redisKey);
+        //     if (!value)
+        //     {
+        //         spdlog::info("Redis中未找到{}数据，初始化为空工位", positionName);
+        //         position.Clear();  // 确保为空
+        //         return true;  // 返回true表示正常状态
+        //     }
+        //     // 调用工位的恢复方法
+        //     return position.RestoreFromJson(*value, positionName);
+        // };
 
         // 2. 恢复生产计划
-        bool planRestored = false;
-        if (redis)
-        {
-            // 从Redis获取生产计划数据并恢复
-            auto planValue = redis->get("PlanInfo");
-            if (planValue)
-            {
-                planRestored = prodPlan.RestoreFromJson(*planValue);
-            }
-        }
+        prodPlan.RestoreFromRedis(); // 先尝试从Redis恢复生产计划
+        // bool planRestored = false;
+        // if (redis)
+        // {
+        //     // 从Redis获取生产计划数据并恢复
+        //     auto planValue = redis->get("PlanInfo");
+        //     if (planValue)
+        //     {
+        //         planRestored = prodPlan.RestoreFromJson(*planValue);
+        //     }
+        // }
 
-        if (!planRestored)
-        {
-            prodPlan.Initialize(); // 无Redis状态时回退到数据库初始化生产计划
-        }
+        // if (!planRestored)
+        // {
+        //     prodPlan.Initialize(); // 无Redis状态时回退到数据库初始化生产计划
+        // }
 
         // 3. 恢复各个工位状态
-        restorePosition(alignPos, "ALIGN_POS_TUBE_INFO", "对齐工位");
-        restorePosition(weightPos, "WEIGHT_POS_TUBE_INFO", "称重工位");
-        restorePosition(carvePos, "CARVE_POS_TUBE_INFO", "刻印工位");
-        restorePosition(sprayPos, "SPRAY_POS_TUBE_INFO", "喷印工位");
-        restorePosition(circlePos, "CIRCLE_POS_TUBE_INFO", "色环工位");
-        restorePosition(scraptRoller, "SCRAPTROLLER_POS_TUBE_INFO", "废料辊道");
-        restorePosition(backBuffer, "BACKBUFFER_POS_TUBE_INFO", "缓冲区");
-        restorePosition(scrapt, "SCRAPT_POS_TUBE_INFO", "废料筐");
-        restorePosition(basket, "BASKET_POS_TUBE_INFO", "成品筐");
+        alignPos.RestoreFromRedis();
+        weightPos.RestoreFromRedis();   
+        carvePos.RestoreFromRedis();
+        sprayPos.RestoreFromRedis();
+        circlePos.RestoreFromRedis();
+        scraptRoller.RestoreFromRedis();
+        backBuffer.RestoreFromRedis();
+        scrapt.RestoreFromRedis();
+        basket.RestoreFromRedis();
+        // restorePosition(alignPos, "ALIGN_POS_TUBE_INFO", "对齐工位");
+        // restorePosition(weightPos, "WEIGHT_POS_TUBE_INFO", "称重工位");
+        // restorePosition(carvePos, "CARVE_POS_TUBE_INFO", "刻印工位");
+        // restorePosition(sprayPos, "SPRAY_POS_TUBE_INFO", "喷印工位");
+        // restorePosition(circlePos, "CIRCLE_POS_TUBE_INFO", "色环工位");
+        // restorePosition(scraptRoller, "SCRAPTROLLER_POS_TUBE_INFO", "废料辊道");
+        // restorePosition(backBuffer, "BACKBUFFER_POS_TUBE_INFO", "缓冲区");
+        // restorePosition(scrapt, "SCRAPT_POS_TUBE_INFO", "废料筐");
+        // restorePosition(basket, "BASKET_POS_TUBE_INFO", "成品筐");
     }
 
     // 清理资源

--- a/TubeTrack/include/WeightPosition.h
+++ b/TubeTrack/include/WeightPosition.h
@@ -5,10 +5,7 @@
 class CWeightPosition : public CPositionBase
 {
 public:
-    CWeightPosition() = default;
-    ~CWeightPosition() = default;
+    CWeightPosition(string redisKey, string positionName) : CPositionBase(redisKey, positionName) {}
 
     virtual void UpdateForm() override; // 刷新画面
-private:
-    const char *REDIS_KEY = "WEIGHT_POS_TUBE_INFO"; // 发布的key名称
 };

--- a/TubeTrack/src/AlignPosition.cpp
+++ b/TubeTrack/src/AlignPosition.cpp
@@ -7,10 +7,10 @@ void CAlignPosition::UpdateForm()
 {
     // 刷新对齐工位的界面显示
     if (m_ctx && m_ctx->redis) {
-        m_ctx->redis->set(REDIS_KEY, convertToJson());
+        m_ctx->redis->set(m_redisKey, convertToJson());
         spdlog::info("AlignPosition: ALIGN_POS_TUBE_INFO updated");
 
         // 发布详细消息到 RealDataChanged 主题
-        m_ctx->redis->publish("RealDataChanged", REDIS_KEY);
+        m_ctx->redis->publish("RealDataChanged", m_redisKey);
     }
 }

--- a/TubeTrack/src/AlignPosition.cpp
+++ b/TubeTrack/src/AlignPosition.cpp
@@ -8,7 +8,7 @@ void CAlignPosition::UpdateForm()
     // 刷新对齐工位的界面显示
     if (m_ctx && m_ctx->redis) {
         m_ctx->redis->set(m_redisKey, convertToJson());
-        spdlog::info("AlignPosition: ALIGN_POS_TUBE_INFO updated");
+        spdlog::info("{}: {} updated", m_positionName, m_redisKey);
 
         // 发布详细消息到 RealDataChanged 主题
         m_ctx->redis->publish("RealDataChanged", m_redisKey);

--- a/TubeTrack/src/BackBuffer.cpp
+++ b/TubeTrack/src/BackBuffer.cpp
@@ -8,10 +8,10 @@ void CBackBuffer::UpdateForm()
     // 刷新测量点后缓冲区的界面显示
     if (m_ctx && m_ctx->redis)
     {
-        m_ctx->redis->set(REDIS_KEY, convertToJson());
+        m_ctx->redis->set(m_redisKey, convertToJson());
         spdlog::info("BackBuffer: BACKBUFFER_POS_TUBE_INFO updated");
         // 发布详细消息到 RealDataChanged 主题
-        m_ctx->redis->publish("RealDataChanged", REDIS_KEY);
+        m_ctx->redis->publish("RealDataChanged", m_redisKey);
     }
 }
 

--- a/TubeTrack/src/BackBuffer.cpp
+++ b/TubeTrack/src/BackBuffer.cpp
@@ -9,7 +9,7 @@ void CBackBuffer::UpdateForm()
     if (m_ctx && m_ctx->redis)
     {
         m_ctx->redis->set(m_redisKey, convertToJson());
-        spdlog::info("BackBuffer: BACKBUFFER_POS_TUBE_INFO updated");
+        spdlog::info("{}: {} updated", m_positionName, m_redisKey);
         // 发布详细消息到 RealDataChanged 主题
         m_ctx->redis->publish("RealDataChanged", m_redisKey);
     }
@@ -17,10 +17,10 @@ void CBackBuffer::UpdateForm()
 
 void CBackBuffer::DebugOut()
 {
-    spdlog::info("BackBuffer tube count: {}", Count());
+    spdlog::info("{} tube count: {}", m_positionName, Count());
     // 输出测量点后缓冲区管子数量
     if (m_ctx && m_ctx->redis)
     {
-        spdlog::info("BackBuffer: BACKBUFFER_POS_TUBE_INFO = {}", convertToJson());
+        spdlog::info("{}: {} = {}", m_positionName, m_redisKey, convertToJson());
     }
 }

--- a/TubeTrack/src/Basket.cpp
+++ b/TubeTrack/src/Basket.cpp
@@ -9,7 +9,7 @@ void CBasket::UpdateForm()
     if (m_ctx && m_ctx->redis)
     {
         m_ctx->redis->set(m_redisKey, convertToJson());
-        spdlog::info("Basket: BASKET_POS_TUBE_INFO updated");
+        spdlog::info("{}: {} updated", m_positionName, m_redisKey);
         // 发布详细消息到 RealDataChanged 主题
         m_ctx->redis->publish("RealDataChanged", m_redisKey);
     }
@@ -20,6 +20,7 @@ void CBasket::DebugOut()
     // 输出成品料筐管子数量
     if (m_ctx && m_ctx->redis)
     {
-        spdlog::info("Basket: BASKET_POS_TUBE_INFO = {}", convertToJson());
+        spdlog::info("{} tube count: {}", m_positionName, Count());
+        spdlog::info("{}: {} = {}", m_positionName, m_redisKey, convertToJson());
     }
 }

--- a/TubeTrack/src/Basket.cpp
+++ b/TubeTrack/src/Basket.cpp
@@ -8,10 +8,10 @@ void CBasket::UpdateForm()
     // 刷新成品料筐的界面显示
     if (m_ctx && m_ctx->redis)
     {
-        m_ctx->redis->set(REDIS_KEY, convertToJson());
+        m_ctx->redis->set(m_redisKey, convertToJson());
         spdlog::info("Basket: BASKET_POS_TUBE_INFO updated");
         // 发布详细消息到 RealDataChanged 主题
-        m_ctx->redis->publish("RealDataChanged", REDIS_KEY);
+        m_ctx->redis->publish("RealDataChanged", m_redisKey);
     }
 }
 

--- a/TubeTrack/src/CarvePosition.cpp
+++ b/TubeTrack/src/CarvePosition.cpp
@@ -8,7 +8,7 @@ void CCarvePosition::UpdateForm()
     // 刷新刻印工位的界面显示
     if (m_ctx && m_ctx->redis) {
         m_ctx->redis->set(m_redisKey, convertToJson());
-        spdlog::info("CarvePosition: CARVE_POS_TUBE_INFO updated");
+        spdlog::info("{}: {} updated", m_positionName, m_redisKey);
 
         // 发布详细消息到 RealDataChanged 主题
         m_ctx->redis->publish("RealDataChanged", m_redisKey);

--- a/TubeTrack/src/CarvePosition.cpp
+++ b/TubeTrack/src/CarvePosition.cpp
@@ -7,10 +7,10 @@ void CCarvePosition::UpdateForm()
 {
     // 刷新刻印工位的界面显示
     if (m_ctx && m_ctx->redis) {
-        m_ctx->redis->set(REDIS_KEY, convertToJson());
+        m_ctx->redis->set(m_redisKey, convertToJson());
         spdlog::info("CarvePosition: CARVE_POS_TUBE_INFO updated");
 
         // 发布详细消息到 RealDataChanged 主题
-        m_ctx->redis->publish("RealDataChanged", REDIS_KEY);
+        m_ctx->redis->publish("RealDataChanged", m_redisKey);
     }
 }

--- a/TubeTrack/src/CirclePosition.cpp
+++ b/TubeTrack/src/CirclePosition.cpp
@@ -9,7 +9,7 @@ void CCirclePosition::UpdateForm()
     if (m_ctx && m_ctx->redis)
     {
         m_ctx->redis->set(m_redisKey, convertToJson());
-        spdlog::info("CirclePosition: CIRCLE_POS_TUBE_INFO updated");
+        spdlog::info("{}: {} updated", m_positionName, m_redisKey);
 
         // 发布详细消息到 RealDataChanged 主题
         m_ctx->redis->publish("RealDataChanged", m_redisKey);

--- a/TubeTrack/src/CirclePosition.cpp
+++ b/TubeTrack/src/CirclePosition.cpp
@@ -8,10 +8,10 @@ void CCirclePosition::UpdateForm()
     // 刷新色环工位的界面显示
     if (m_ctx && m_ctx->redis)
     {
-        m_ctx->redis->set(REDIS_KEY, convertToJson());
+        m_ctx->redis->set(m_redisKey, convertToJson());
         spdlog::info("CirclePosition: CIRCLE_POS_TUBE_INFO updated");
 
         // 发布详细消息到 RealDataChanged 主题
-        m_ctx->redis->publish("RealDataChanged", REDIS_KEY);
+        m_ctx->redis->publish("RealDataChanged", m_redisKey);
     }
 }

--- a/TubeTrack/src/PositionBase.cpp
+++ b/TubeTrack/src/PositionBase.cpp
@@ -119,7 +119,7 @@ bool CPositionBase::PushAt(unique_ptr<CTube> tube, int seqNo)
 	// }
 
 	// 在指定位置插入管子
-	CTube *tubePtr = tube.get();
+	// CTube *tubePtr = tube.get();
 	auto it = m_tubes.begin() + insertIndex;
 	m_tubes.insert(it, std::move(tube));
 	UpdateForm();

--- a/TubeTrack/src/PositionBase.cpp
+++ b/TubeTrack/src/PositionBase.cpp
@@ -113,10 +113,10 @@ bool CPositionBase::PushAt(unique_ptr<CTube> tube, int seqNo)
 		return PushBack(std::move(tube));
 	}
 
-	if (m_bTriggerEnabled)
-	{
-		EntryTriggerBeforePush(*tube);
-	}
+	// if (m_bTriggerEnabled)
+	// {
+	// 	EntryTriggerBeforePush(*tube);
+	// }
 
 	// 在指定位置插入管子
 	CTube *tubePtr = tube.get();
@@ -124,10 +124,10 @@ bool CPositionBase::PushAt(unique_ptr<CTube> tube, int seqNo)
 	m_tubes.insert(it, std::move(tube));
 	UpdateForm();
 
-	if (m_bTriggerEnabled)
-	{
-		EntryTrigger(*tubePtr);
-	}
+	// if (m_bTriggerEnabled)
+	// {
+	// 	EntryTrigger(*tubePtr);
+	// }
 
 	return true;
 }
@@ -266,14 +266,15 @@ bool CPositionBase::Delete(int seqNo)
 		return false;
 	}
 
-	auto it = m_tubes.begin() + static_cast<ptrdiff_t>(index);
-	auto tube = std::move(*it);
+	// auto it = m_tubes.begin() + static_cast<ptrdiff_t>(index);
+	auto it = m_tubes.begin() + index;
+	// auto tube = std::move(*it);
 	m_tubes.erase(it);
 	UpdateForm();
-	if (m_bTriggerEnabled && tube)
-	{
-		ExitTrigger(*tube);
-	}
+	// if (m_bTriggerEnabled && tube)
+	// {
+	// 	ExitTrigger(*tube);
+	// }
 	return true;
 }
 

--- a/TubeTrack/src/PositionBase.cpp
+++ b/TubeTrack/src/PositionBase.cpp
@@ -1,31 +1,25 @@
 #include "PositionBase.h"
+#include "TubeTrackContext.h"
 #include <iostream>
 #include <sstream>
 #include <iomanip>
 #include <utility>
 #include <nlohmann/json.hpp>
-#include "../../include/logging.h"   // spdlog
+#include "../../include/logging.h" // spdlog
 
-CPositionBase::CPositionBase()
+void CPositionBase::GetDateTime(struct tm &t)
 {
-	m_bTriggerEnabled	= true;
-	m_bUpdateTagEnabled = true;
-	m_bWbReleased = true;
+	time_t now;			   // 声明time_t类型变量
+	time(&now);			   // 获取系统日期和时间
+	localtime_r(&now, &t); // 获取当地日期和时间
 }
 
-void CPositionBase::GetDateTime(struct tm & t)
+void CPositionBase::GetDateTimeString(string &dateStr, string &timeStr)
 {
-	time_t now;             //声明time_t类型变量
-	time(&now);				//获取系统日期和时间
-	localtime_r(&now, &t);  //获取当地日期和时间
-}
-
-void CPositionBase::GetDateTimeString(string & dateStr, string & timeStr)
-{
-	struct tm t;			//tm结构指针
-	time_t now;             //声明time_t类型变量
-	time(&now);				//获取系统日期和时间
-	localtime_r(&now, &t);  //获取当地日期和时间
+	struct tm t;		   // tm结构指针
+	time_t now;			   // 声明time_t类型变量
+	time(&now);			   // 获取系统日期和时间
+	localtime_r(&now, &t); // 获取当地日期和时间
 
 	// 输出 tm 结构的各个组成部分
 	std::stringstream ss1, ss2;
@@ -88,7 +82,7 @@ bool CPositionBase::PushAt(unique_ptr<CTube> tube, int seqNo)
 	}
 
 	// 计算插入位置的索引
-	ptrdiff_t insertIndex = 0;// 使用有符号整数，支持负数计算结果
+	ptrdiff_t insertIndex = 0; // 使用有符号整数，支持负数计算结果
 	if (seqNo >= 0)
 	{
 		// 正向插入：0→第一个位置，1→第二个位置，2→第三个位置...
@@ -107,7 +101,7 @@ bool CPositionBase::PushAt(unique_ptr<CTube> tube, int seqNo)
 		return false;
 	}
 
-	//末尾插入直接调用 PushBack函数
+	// 末尾插入直接调用 PushBack函数
 	if (insertIndex == static_cast<ptrdiff_t>(m_tubes.size()))
 	{
 		return PushBack(std::move(tube));
@@ -132,7 +126,7 @@ bool CPositionBase::PushAt(unique_ptr<CTube> tube, int seqNo)
 	return true;
 }
 
-//默认从后端插入管子
+// 默认从后端插入管子
 bool CPositionBase::Push(unique_ptr<CTube> tube, int mode)
 {
 	return PushBack(std::move(tube), mode);
@@ -148,7 +142,7 @@ unique_ptr<CTube> CPositionBase::PopFront(int /*mode*/)
 		if (m_bTriggerEnabled && tube)
 		{
 			ExitTrigger(*tube);
-		}	
+		}
 		return tube;
 	}
 	else
@@ -167,7 +161,7 @@ unique_ptr<CTube> CPositionBase::PopBack(int /*mode*/)
 		if (m_bTriggerEnabled && tube)
 		{
 			ExitTrigger(*tube);
-		}	
+		}
 		return tube;
 	}
 	else
@@ -176,7 +170,7 @@ unique_ptr<CTube> CPositionBase::PopBack(int /*mode*/)
 	}
 }
 
-//默认从前端弹出管子
+// 默认从前端弹出管子
 unique_ptr<CTube> CPositionBase::Pop(int /*mode*/)
 {
 	return PopFront();
@@ -252,10 +246,10 @@ bool CPositionBase::Delete(int seqNo)
 	{
 		return false;
 	}
-	//如果seqNo=-1,则清空该工位队列所有管子
+	// 如果seqNo=-1,则清空该工位队列所有管子
 	if (seqNo == -1)
 	{
-		//调用Clear()函数清空管子队列并更新画面
+		// 调用Clear()函数清空管子队列并更新画面
 		Clear();
 		return true;
 	}
@@ -282,37 +276,57 @@ void CPositionBase::RestoreFromTag()
 {
 }
 
-bool CPositionBase::RestoreFromJson(const string &jsonStr, const char *sourceName)
+void CPositionBase::RestoreFromRedis()
+{
+	if (!m_ctx || !m_ctx->redis)
+	{
+		return;
+	}
+
+	// 从Redis获取数据并恢复
+	auto value = m_ctx->redis->get(m_redisKey);
+	if (!value)
+	{
+		spdlog::info("Redis中未找到{}数据，初始化为空工位", m_redisKey);
+		Clear();	 // 确保为空
+		return; // 返回true表示正常状态
+	}
+	// 调用工位的恢复方法
+	return RestoreFromJson(*value);
+}
+
+void CPositionBase::RestoreFromJson(const string &jsonStr)
 {
 	try
 	{
 		// 情况1：redis数据为空(首次启动)
 		if (jsonStr.empty())
 		{
-			spdlog::info("{} 首次启动，初始化为空工位", sourceName ? sourceName : "Position");
+			spdlog::info("{} 首次启动，初始化为空工位", m_positionName);
 			m_tubes.clear();
-			return true; // 正常状态
+			return; // 正常状态
 		}
 
 		// 情况2：有数据但为空JSON对象
 		nlohmann::json j = nlohmann::json::parse(jsonStr);
 
-		if (!m_tubes.empty())
-		{
-			spdlog::warn("{} 非空状态下执行恢复，将覆盖现有数据", sourceName);
-			m_tubes.clear();
-		}
+		// if (!m_tubes.empty())
+		// {
+		// 	spdlog::warn("{} 非空状态下执行恢复，将覆盖现有数据", m_positionName);
+		// 	m_tubes.clear();
+		// }
+		m_tubes.clear();
 		// 处理空对象 {} 和空数组 [] 两种情况
 		if (j.is_object() && j.empty())
 		{
-			spdlog::info("{} 从Redis恢复为空工位", sourceName ? sourceName : "Position");
-			return true;
+			spdlog::info("{} 从Redis恢复为空工位", m_positionName);
+			return;
 		}
 		// 情况3：数据格式错误
 		if (!j.is_array())
 		{
-			spdlog::warn("{} Redis数据格式不是数组，跳过恢复: {}", sourceName ? sourceName : "Position", jsonStr);
-			return false;
+			spdlog::error("{} Redis数据格式不是数组，跳过恢复: {}", m_positionName, jsonStr);
+			return;
 		}
 		// 情况4：正常恢复数据
 		for (const auto &tubeJson : j)
@@ -335,13 +349,11 @@ bool CPositionBase::RestoreFromJson(const string &jsonStr, const char *sourceNam
 			m_tubes.push_back(std::move(tube));
 		}
 
-		spdlog::info("{} 从Redis恢复了 {} 根管子", sourceName ? sourceName : "Position", m_tubes.size());
-		return true;
+		spdlog::info("{} 从Redis恢复了 {} 根管子", m_positionName, m_tubes.size());
 	}
 	catch (const std::exception &e)
 	{
-		spdlog::error("{} Redis恢复失败: {}", sourceName ? sourceName : "Position", e.what());
-		return false;
+		spdlog::error("{} Redis恢复失败: {}", m_positionName, e.what());
 	}
 }
 
@@ -395,20 +407,20 @@ void CPositionBase::DebugOut()
 {
 	const CTube *tube = Peek();
 	if (!tube)
-    {
-        std::cout << "没有管子信息" << std::endl;
-        return;
-    }
+	{
+		std::cout << "没有管子信息" << std::endl;
+		return;
+	}
 
-    // std::cout << "合同号    :" << tube.order_no << std::endl;
-    // std::cout << "项目号    :" << tube.item_no << std::endl;
-    // std::cout << "轧批号    :" << tube.roll_no << std::endl;
-    // std::cout << "炉号      :" << tube.melt_no << std::endl;
-    // std::cout << "试批号    :" << tube.lot_no << std::endl;
-    // std::cout << "管号      :" << tube.tube_no << std::endl;
-    // std::cout << "流水号    :" << tube.flow_no << std::endl;
-    // std::cout << "接箍批号  :" << tube.lotno_coupling << std::endl;
-    // std::cout << "接箍炉号  :" << tube.meltno_coupling << std::endl;
+	// std::cout << "合同号    :" << tube.order_no << std::endl;
+	// std::cout << "项目号    :" << tube.item_no << std::endl;
+	// std::cout << "轧批号    :" << tube.roll_no << std::endl;
+	// std::cout << "炉号      :" << tube.melt_no << std::endl;
+	// std::cout << "试批号    :" << tube.lot_no << std::endl;
+	// std::cout << "管号      :" << tube.tube_no << std::endl;
+	// std::cout << "流水号    :" << tube.flow_no << std::endl;
+	// std::cout << "接箍批号  :" << tube.lotno_coupling << std::endl;
+	// std::cout << "接箍炉号  :" << tube.meltno_coupling << std::endl;
 	spdlog::info("合同号    : {}", tube->order_no);
 	spdlog::info("项目号    : {}", tube->item_no);
 	spdlog::info("轧批号    : {}", tube->roll_no);
@@ -419,15 +431,13 @@ void CPositionBase::DebugOut()
 	spdlog::info("接箍批号  : {}", tube->lotno_coupling);
 	spdlog::info("接箍炉号  : {}", tube->meltno_coupling);
 
-
-    // 数值格式化输出
-    // std::cout << std::fixed << std::setprecision(3);
-    // std::cout << "长度 (m)  :" << tube.length << std::endl;
-    // std::cout << "重量 (kg) :" << tube.weight << std::endl;
-    // std::cout << std::defaultfloat; // 恢复默认格式
+	// 数值格式化输出
+	// std::cout << std::fixed << std::setprecision(3);
+	// std::cout << "长度 (m)  :" << tube.length << std::endl;
+	// std::cout << "重量 (kg) :" << tube.weight << std::endl;
+	// std::cout << std::defaultfloat; // 恢复默认格式
 	spdlog::info("长度 (m)  : {}", tube->length);
 	spdlog::info("重量 (kg) : {}", tube->weight);
-
 
 	// std::cout << "长度合格  :" << (tube.lengthOk ? "是" : "否") << std::endl;
 	// std::cout << "重量合格  :" << (tube.weightOk ? "是" : "否") << std::endl;
@@ -436,7 +446,7 @@ void CPositionBase::DebugOut()
 	spdlog::info("重量合格  : {}", tube->weight_ok ? "是" : "否");
 	spdlog::info("是否喷印  : {}", tube->sprayed ? "是" : "否");
 
-    return;
+	return;
 }
 
 // string CPositionBase::convertToJson(const CTube & tube)
@@ -461,7 +471,7 @@ void CPositionBase::DebugOut()
 //     return j.dump(4);
 // }
 
-//直接获取当前工位管子信息并转换为JSON字符串
+// 直接获取当前工位管子信息并转换为JSON字符串
 string CPositionBase::convertToJson()
 {
 	if (m_tubes.empty())
@@ -471,7 +481,7 @@ string CPositionBase::convertToJson()
 
 	// 枚举当前工位的所有管子并转换为JSON数组
 	nlohmann::json j = nlohmann::json::array();
-	for (const auto& tubePtr : m_tubes)
+	for (const auto &tubePtr : m_tubes)
 	{
 		if (tubePtr)
 		{

--- a/TubeTrack/src/PositionBase.cpp
+++ b/TubeTrack/src/PositionBase.cpp
@@ -107,21 +107,10 @@ bool CPositionBase::PushAt(unique_ptr<CTube> tube, int seqNo)
 		return PushBack(std::move(tube));
 	}
 
-	// if (m_bTriggerEnabled)
-	// {
-	// 	EntryTriggerBeforePush(*tube);
-	// }
-
 	// 在指定位置插入管子
-	// CTube *tubePtr = tube.get();
 	auto it = m_tubes.begin() + insertIndex;
 	m_tubes.insert(it, std::move(tube));
 	UpdateForm();
-
-	// if (m_bTriggerEnabled)
-	// {
-	// 	EntryTrigger(*tubePtr);
-	// }
 
 	return true;
 }
@@ -260,15 +249,10 @@ bool CPositionBase::Delete(int seqNo)
 		return false;
 	}
 
-	// auto it = m_tubes.begin() + static_cast<ptrdiff_t>(index);
 	auto it = m_tubes.begin() + index;
-	// auto tube = std::move(*it);
 	m_tubes.erase(it);
 	UpdateForm();
-	// if (m_bTriggerEnabled && tube)
-	// {
-	// 	ExitTrigger(*tube);
-	// }
+
 	return true;
 }
 
@@ -288,8 +272,8 @@ void CPositionBase::RestoreFromRedis()
 	if (!value)
 	{
 		spdlog::info("Redis中未找到{}数据，初始化为空工位", m_redisKey);
-		Clear();	 // 确保为空
-		return; // 返回true表示正常状态
+		Clear(); // 确保为空
+		return;	 // 返回true表示正常状态
 	}
 	// 调用工位的恢复方法
 	return RestoreFromJson(*value);
@@ -310,14 +294,9 @@ void CPositionBase::RestoreFromJson(const string &jsonStr)
 		// 情况2：有数据但为空JSON对象
 		nlohmann::json j = nlohmann::json::parse(jsonStr);
 
-		// if (!m_tubes.empty())
-		// {
-		// 	spdlog::warn("{} 非空状态下执行恢复，将覆盖现有数据", m_positionName);
-		// 	m_tubes.clear();
-		// }
 		m_tubes.clear();
-		// 处理空对象 {} 和空数组 [] 两种情况
-		if (j.is_object() && j.empty())
+
+		if (j.is_object() && j.empty()) // 处理空对象 {} 和空数组 [] 两种情况
 		{
 			spdlog::info("{} 从Redis恢复为空工位", m_positionName);
 			return;
@@ -412,15 +391,6 @@ void CPositionBase::DebugOut()
 		return;
 	}
 
-	// std::cout << "合同号    :" << tube.order_no << std::endl;
-	// std::cout << "项目号    :" << tube.item_no << std::endl;
-	// std::cout << "轧批号    :" << tube.roll_no << std::endl;
-	// std::cout << "炉号      :" << tube.melt_no << std::endl;
-	// std::cout << "试批号    :" << tube.lot_no << std::endl;
-	// std::cout << "管号      :" << tube.tube_no << std::endl;
-	// std::cout << "流水号    :" << tube.flow_no << std::endl;
-	// std::cout << "接箍批号  :" << tube.lotno_coupling << std::endl;
-	// std::cout << "接箍炉号  :" << tube.meltno_coupling << std::endl;
 	spdlog::info("合同号    : {}", tube->order_no);
 	spdlog::info("项目号    : {}", tube->item_no);
 	spdlog::info("轧批号    : {}", tube->roll_no);
@@ -432,16 +402,9 @@ void CPositionBase::DebugOut()
 	spdlog::info("接箍炉号  : {}", tube->meltno_coupling);
 
 	// 数值格式化输出
-	// std::cout << std::fixed << std::setprecision(3);
-	// std::cout << "长度 (m)  :" << tube.length << std::endl;
-	// std::cout << "重量 (kg) :" << tube.weight << std::endl;
-	// std::cout << std::defaultfloat; // 恢复默认格式
 	spdlog::info("长度 (m)  : {}", tube->length);
 	spdlog::info("重量 (kg) : {}", tube->weight);
 
-	// std::cout << "长度合格  :" << (tube.lengthOk ? "是" : "否") << std::endl;
-	// std::cout << "重量合格  :" << (tube.weightOk ? "是" : "否") << std::endl;
-	// std::cout << "是否喷印  :" << (tube.bSprayed ? "是" : "否") << std::endl;
 	spdlog::info("长度合格  : {}", tube->length_ok ? "是" : "否");
 	spdlog::info("重量合格  : {}", tube->weight_ok ? "是" : "否");
 	spdlog::info("是否喷印  : {}", tube->sprayed ? "是" : "否");

--- a/TubeTrack/src/ProductionPlan.cpp
+++ b/TubeTrack/src/ProductionPlan.cpp
@@ -71,10 +71,10 @@ void CProductionPlan::UpdateForm()
         }
 
         // 写入Redis数据库
-        m_ctx->redis->set(REDIS_KEY, jsonStr);
+        m_ctx->redis->set(m_redisKey, jsonStr);
 
         // 发布详细消息到 RealDataChanged 主题
-        m_ctx->redis->publish("RealDataChanged", REDIS_KEY);
+        m_ctx->redis->publish("RealDataChanged", m_redisKey);
 
         spdlog::info("生产计划已更新并发布到Redis: {}", jsonStr);
     }
@@ -103,19 +103,18 @@ void CProductionPlan::Initialize()
         {
             const auto &row = result[0];
 
-            this->order_no = row["order_no"].as<string>();                       // 合同号
-            this->item_no = row["item_no"].as<string>();                          // 项目号
-            this->roll_no = row["roll_no"].as<string>();                          // 轧批号
-            this->melt_no = row["melt_no"].as<string>();                          // 炉号
-            this->lot_no = row["lot_no"].as<string>();                             // 试批号
-            this->lotno_coupling = row["lot_no_coupling"].as<string>();    // 接箍批号
+            this->order_no = row["order_no"].as<string>();                // 合同号
+            this->item_no = row["item_no"].as<string>();                  // 项目号
+            this->roll_no = row["roll_no"].as<string>();                  // 轧批号
+            this->melt_no = row["melt_no"].as<string>();                  // 炉号
+            this->lot_no = row["lot_no"].as<string>();                    // 试批号
+            this->lotno_coupling = row["lot_no_coupling"].as<string>();   // 接箍批号
             this->meltno_coupling = row["melt_no_coupling"].as<string>(); // 接箍炉号
-            this->feed_num = row["feed_number"].as<int>();                       // 投料支数
-            this->tube_no = row["tube_no"].as<int>();                             // 管号
-        
+            this->feed_num = row["feed_number"].as<int>();                // 投料支数
+            this->tube_no = row["tube_no"].as<int>();                     // 管号
+
             spdlog::info("从数据库加载生产计划参数成功  order_no: {}", this->order_no);
         }
-
     }
     catch (const std::exception &e)
     {
@@ -130,7 +129,7 @@ bool CProductionPlan::ApplyCurrentContract(const string &orderNo, const string &
 {
     try
     {
-        //根据合同号、项目号查询批号、外径、壁厚等生产参数
+        // 根据合同号、项目号查询批号、外径、壁厚等生产参数
         pqxx::work txn(*m_ctx->pgConn);
         const pqxx::result queryResult = txn.exec(
             "SELECT roll_no, diameter, wall_thickness FROM api_order_data_t "
@@ -143,13 +142,14 @@ bool CProductionPlan::ApplyCurrentContract(const string &orderNo, const string &
             return false;
         }
 
-        //更新生产参数表相关字段
+        // 更新生产参数表相关字段
         const std::string rollNo = queryResult[0]["roll_no"].as<std::string>("");
         const double Diameter = queryResult[0]["diameter"].as<double>(0.0);
         const double wallThickness = queryResult[0]["wall_thickness"].as<double>(0.0);
         const auto updatedRows = txn.exec(
-            "UPDATE parameter_set SET order_no = $1, item_no = $2, roll_no = $3, diameter = $4, wall_thickness = $5",
-            pqxx::params{orderNo, itemNo, rollNo, Diameter, wallThickness}).affected_rows();
+                                        "UPDATE parameter_set SET order_no = $1, item_no = $2, roll_no = $3, diameter = $4, wall_thickness = $5",
+                                        pqxx::params{orderNo, itemNo, rollNo, Diameter, wallThickness})
+                                     .affected_rows();
 
         if (updatedRows == 0)
         {
@@ -159,7 +159,7 @@ bool CProductionPlan::ApplyCurrentContract(const string &orderNo, const string &
 
         txn.commit();
 
-        //更新内部状态并刷新画面
+        // 更新内部状态并刷新画面
         order_no = orderNo;
         item_no = itemNo;
         roll_no = rollNo;
@@ -177,21 +177,36 @@ bool CProductionPlan::ApplyCurrentContract(const string &orderNo, const string &
     }
 }
 
-bool CProductionPlan::RestoreFromJson(const string &jsonStr)
+void CProductionPlan::RestoreFromRedis()
+{
+    if (m_ctx && m_ctx->redis)
+    {
+        // 从Redis获取生产计划数据并恢复
+        auto planValue = m_ctx->redis->get("PlanInfo");
+        if (planValue)
+        {
+            RestoreFromJson(*planValue);
+        }
+    }
+}
+
+void CProductionPlan::RestoreFromJson(const string &jsonStr)
 {
     try
     {
         if (jsonStr.empty())
         {
             spdlog::warn("PlanInfo Redis数据为空，跳过恢复");
-            return false;
+            Initialize(); // 无Redis状态时回退到数据库初始化生产计划
+            return;
         }
 
         nlohmann::json j = nlohmann::json::parse(jsonStr);
         if (!j.is_object() || j.empty())
         {
-            spdlog::warn("PlanInfo Redis数据为空对象或格式错误，跳过恢复");
-            return false;
+            spdlog::error("PlanInfo Redis数据为空对象或格式错误，跳过恢复");
+            Initialize(); // 无Redis状态时回退到数据库初始化生产计划
+            return;
         }
 
         order_no = j.value("order_no", "");
@@ -205,16 +220,14 @@ bool CProductionPlan::RestoreFromJson(const string &jsonStr)
         tube_no = j.value("tube_no", 0);
 
         spdlog::info("从Redis恢复生产计划成功 order_no: {}", order_no);
-        return true;
     }
     catch (const std::exception &e)
     {
         spdlog::error("从Redis恢复生产计划失败: {}", e.what());
-        return false;
     }
 }
 
 bool CProductionPlan::IsEmpty()
 {
-	return feed_num <= 0;
+    return feed_num <= 0;
 }

--- a/TubeTrack/src/ProductionPlan.cpp
+++ b/TubeTrack/src/ProductionPlan.cpp
@@ -182,7 +182,7 @@ void CProductionPlan::RestoreFromRedis()
     if (m_ctx && m_ctx->redis)
     {
         // 从Redis获取生产计划数据并恢复
-        auto planValue = m_ctx->redis->get("PlanInfo");
+        auto planValue = m_ctx->redis->get(m_redisKey);
         if (planValue)
         {
             RestoreFromJson(*planValue);
@@ -196,7 +196,7 @@ void CProductionPlan::RestoreFromJson(const string &jsonStr)
     {
         if (jsonStr.empty())
         {
-            spdlog::warn("PlanInfo Redis数据为空，跳过恢复");
+            spdlog::warn("{} Redis数据为空，跳过恢复", m_redisKey);
             Initialize(); // 无Redis状态时回退到数据库初始化生产计划
             return;
         }
@@ -204,7 +204,7 @@ void CProductionPlan::RestoreFromJson(const string &jsonStr)
         nlohmann::json j = nlohmann::json::parse(jsonStr);
         if (!j.is_object() || j.empty())
         {
-            spdlog::error("PlanInfo Redis数据为空对象或格式错误，跳过恢复");
+            spdlog::error("{} Redis数据为空对象或格式错误，跳过恢复", m_redisKey);
             Initialize(); // 无Redis状态时回退到数据库初始化生产计划
             return;
         }

--- a/TubeTrack/src/Scrapt.cpp
+++ b/TubeTrack/src/Scrapt.cpp
@@ -8,11 +8,11 @@ void CScrapt::UpdateForm()
 {
     // 刷新废料筐工位的界面显示
     if (m_ctx && m_ctx->redis) {
-        m_ctx->redis->set(REDIS_KEY, convertToJson());
+        m_ctx->redis->set(m_redisKey, convertToJson());
         spdlog::info("Scrapt: SCRAPT_POS_TUBE_INFO updated");
 
         // 发布详细消息到 RealDataChanged 主题
-        m_ctx->redis->publish("RealDataChanged", REDIS_KEY);
+        m_ctx->redis->publish("RealDataChanged", m_redisKey);
     }
 }
 

--- a/TubeTrack/src/Scrapt.cpp
+++ b/TubeTrack/src/Scrapt.cpp
@@ -9,7 +9,7 @@ void CScrapt::UpdateForm()
     // 刷新废料筐工位的界面显示
     if (m_ctx && m_ctx->redis) {
         m_ctx->redis->set(m_redisKey, convertToJson());
-        spdlog::info("Scrapt: SCRAPT_POS_TUBE_INFO updated");
+        spdlog::info("{}: {} updated", m_positionName, m_redisKey);
 
         // 发布详细消息到 RealDataChanged 主题
         m_ctx->redis->publish("RealDataChanged", m_redisKey);
@@ -21,6 +21,7 @@ void CScrapt::DebugOut()
     // 输出废料筐管子数量
     if (m_ctx && m_ctx->redis)
     {
-        spdlog::info("Scrapt: SCRAPT_POS_TUBE_INFO = {}", convertToJson());
+        spdlog::info("{} tube count: {}", m_positionName, Count());
+        spdlog::info("{}: {} = {}", m_positionName, m_redisKey, convertToJson());
     }
 }

--- a/TubeTrack/src/ScraptRoller.cpp
+++ b/TubeTrack/src/ScraptRoller.cpp
@@ -7,10 +7,10 @@ void CScraptRoller::UpdateForm()
 {
     // 刷新废料辊道工位的界面显示
     if (m_ctx && m_ctx->redis) {
-        m_ctx->redis->set(REDIS_KEY, convertToJson());
+        m_ctx->redis->set(m_redisKey, convertToJson());
         spdlog::info("ScraptRoller: SCRAPTROLLER_POS_TUBE_INFO updated");
 
         // 发布详细消息到 RealDataChanged 主题
-        m_ctx->redis->publish("RealDataChanged", REDIS_KEY);
+        m_ctx->redis->publish("RealDataChanged", m_redisKey);
     }
 }

--- a/TubeTrack/src/ScraptRoller.cpp
+++ b/TubeTrack/src/ScraptRoller.cpp
@@ -8,7 +8,7 @@ void CScraptRoller::UpdateForm()
     // 刷新废料辊道工位的界面显示
     if (m_ctx && m_ctx->redis) {
         m_ctx->redis->set(m_redisKey, convertToJson());
-        spdlog::info("ScraptRoller: SCRAPTROLLER_POS_TUBE_INFO updated");
+        spdlog::info("{}: {} updated", m_positionName, m_redisKey);
 
         // 发布详细消息到 RealDataChanged 主题
         m_ctx->redis->publish("RealDataChanged", m_redisKey);

--- a/TubeTrack/src/SprayPosition.cpp
+++ b/TubeTrack/src/SprayPosition.cpp
@@ -7,10 +7,10 @@ void CSprayPosition::UpdateForm()
 {
     // 刷新喷印工位的界面显示
     if (m_ctx && m_ctx->redis) {
-        m_ctx->redis->set(REDIS_KEY, convertToJson());
+        m_ctx->redis->set(m_redisKey, convertToJson());
         spdlog::info("SprayPosition: SPRAY_POS_TUBE_INFO updated");
 
         // 发布详细消息到 RealDataChanged 主题
-        m_ctx->redis->publish("RealDataChanged", REDIS_KEY);
+        m_ctx->redis->publish("RealDataChanged", m_redisKey);
     }
 }

--- a/TubeTrack/src/SprayPosition.cpp
+++ b/TubeTrack/src/SprayPosition.cpp
@@ -8,7 +8,7 @@ void CSprayPosition::UpdateForm()
     // 刷新喷印工位的界面显示
     if (m_ctx && m_ctx->redis) {
         m_ctx->redis->set(m_redisKey, convertToJson());
-        spdlog::info("SprayPosition: SPRAY_POS_TUBE_INFO updated");
+        spdlog::info("{}: {} updated", m_positionName, m_redisKey);
 
         // 发布详细消息到 RealDataChanged 主题
         m_ctx->redis->publish("RealDataChanged", m_redisKey);

--- a/TubeTrack/src/WalkingBeam.cpp
+++ b/TubeTrack/src/WalkingBeam.cpp
@@ -32,7 +32,7 @@ bool WalkingBeam::Push(unique_ptr<CTube> tube1,
     m_tubes[4] = std::move(tube4);
     m_tubes[5] = std::move(tube5);
     
-    spdlog::info("WalkingBeam: Push operation completed");
+    // spdlog::info("WalkingBeam: Push operation completed");
     // DebugOut();
     
     return true;

--- a/TubeTrack/src/WeightPosition.cpp
+++ b/TubeTrack/src/WeightPosition.cpp
@@ -8,10 +8,10 @@ void CWeightPosition::UpdateForm()
     // 刷新称重工位的界面显示
     if (m_ctx && m_ctx->redis)
     {
-        m_ctx->redis->set(REDIS_KEY, convertToJson());
+        m_ctx->redis->set(m_redisKey, convertToJson());
         spdlog::info("WeightPosition: WEIGHT_POS_TUBE_INFO updated");
 
         // 发布详细消息到 RealDataChanged 主题
-        m_ctx->redis->publish("RealDataChanged", REDIS_KEY);
+        m_ctx->redis->publish("RealDataChanged", m_redisKey);
     }
 }

--- a/TubeTrack/src/WeightPosition.cpp
+++ b/TubeTrack/src/WeightPosition.cpp
@@ -9,7 +9,7 @@ void CWeightPosition::UpdateForm()
     if (m_ctx && m_ctx->redis)
     {
         m_ctx->redis->set(m_redisKey, convertToJson());
-        spdlog::info("WeightPosition: WEIGHT_POS_TUBE_INFO updated");
+        spdlog::info("{}: {} updated", m_positionName, m_redisKey);
 
         // 发布详细消息到 RealDataChanged 主题
         m_ctx->redis->publish("RealDataChanged", m_redisKey);

--- a/TubeTrack/src/workthread.cpp
+++ b/TubeTrack/src/workthread.cpp
@@ -258,7 +258,6 @@ void workThread(TubeTrackContext &ctx)
         }
         catch (const std::exception &ex)
         {
-            // std::cerr << "Error processing tag: " << tagname << ", error: " << ex.what() << std::endl;
             spdlog::error("Error processing tag: {}, error: {}", tagname, ex.what());
             throw; // 继续抛出异常，交由上层处理（可能导致线程退出）
         }
@@ -280,13 +279,6 @@ void handleMoveTubeCmd(TubeTrackContext &ctx, const char *value)
             return;
         }
 
-        // 和Pop逻辑上重复
-        // if (ctx.prodPlan.IsEmpty())
-        // {
-        //     spdlog::warn("Production plan is empty, no tube to move to Align position");
-        //     return;
-        // }
-
         auto tube = ctx.prodPlan.Pop();
         if (!tube)
         {
@@ -294,18 +286,8 @@ void handleMoveTubeCmd(TubeTrackContext &ctx, const char *value)
             return;
         }
 
-        // if (!ctx.alignPos.Push(std::move(tube)))
-        // {
-        //     spdlog::error("Failed to push tube from Production plan to Align position");
-        //     return;
-        // }
-
         ctx.alignPos.Push(std::move(tube));
         ctx.alignPos.DebugOut();
-    }
-    else if (cmd.from == "align" && cmd.to == "plan") // 反向：对齐工位 -> 生产计划
-    {
-        // 判断生产计划是否允许回退管子
     }
     else if (cmd.from == "align" && cmd.to == "weight") // 对齐工位 -> 称重工位
     {
@@ -350,70 +332,28 @@ void handleMoveTubeCmd(TubeTrackContext &ctx, const char *value)
     else if (cmd.from == "scraptroller" && cmd.to == "backbuffer") // 废料辊道 -> 缓冲区
     {
         // 缓冲区是多管子的，直接推送即可，无需判断是否有管子
-        // 判断废料辊道是否有管子
-        // if (ctx.scraptRoller.IsEmpty())
-        // {
-        //     spdlog::warn("Scrapt roller is empty, no tube to move to back buffer");
-        //     return;
-        // }
-        // else
-        // {
-        //     auto tube = ctx.scraptRoller.Pop();
-
-        //     if (!tube)
-        //     {
-        //         spdlog::warn("Scrapt roller is empty, no tube to move to back buffer");
-        //         return;
-        //     }
-        //     else if (!ctx.backBuffer.Push(std::move(tube)))
-        //     {
-        //         spdlog::error("Failed to push tube from Scrapt roller to back buffer");
-        //     }
-        //     else
-        //     {
-        //         ctx.backBuffer.DebugOut();
-        //     }
-        // }
         auto tube = ctx.scraptRoller.Pop();
 
         if (!tube)
         {
+            // 判断废料辊道是否有管子
             spdlog::warn("Scrapt roller is empty, no tube to move to back buffer");
             return;
         }
         ctx.backBuffer.Push(std::move(tube));
         ctx.backBuffer.DebugOut();
     }
-    // 问题在上游发出的 MOVE_TUBE_CMD 参数不包含这个命令，暂时注释掉
-    // （需要修正 gPlat 或命令发送端，把 scaptroller 改成 scraptroller）
     else if (cmd.from == "backbuffer" && cmd.to == "scraptroller") // 反向：缓冲区 -> 废料辊道
     {
         moveTubeBetween(ctx.backBuffer, ctx.scraptRoller, "Back buffer", "Scrapt roller");
     }
-    // 这里画面按钮还没定义命令
     else if (cmd.from == "scraptroller" && cmd.to == "scrapt") // 废料辊道 -> 废料筐
     {
-        // 废料筐是多管子的，直接推送即可，无需判断是否有管子
-        // 判断废料辊道是否有管子
-        // if (ctx.scraptRoller.IsEmpty())
-        // {
-        //     spdlog::warn("Scrapt roller is empty, no tube to move to scrapt");
-        //     return;
-        // }
-        // else
-        // {
-        //     else if (!ctx.scrapt.Push(std::move(tube)))
-        //     {
-        //         spdlog::error("Failed to push tube from Scrapt roller to scrapt");
-        //     }
-        //     else
-        //     {
-        //         ctx.scrapt.DebugOut();
-        //     }
-        // }
+
         auto tube = ctx.scraptRoller.Pop();
         if (!tube)
         {
+            // 判断废料辊道是否有管子
             spdlog::warn("Scrapt roller is empty, no tube to move to scrapt");
             return;
         }
@@ -422,31 +362,8 @@ void handleMoveTubeCmd(TubeTrackContext &ctx, const char *value)
     }
     else if (cmd.from == "backbuffer" && cmd.to == "basket") // 缓冲区 -> 打包区(先进先出)
     {
-        // 打包区是多管子的，直接推送即可，无需判断是否有管子
-        // 判断缓冲区是否有管子
-        // if (ctx.backBuffer.IsEmpty())
-        // {
-        //     spdlog::warn("Back buffer is empty, no tube to move to basket");
-        //     return;
-        // }
-        // else
-        // {
-        //     auto tube = ctx.backBuffer.Pop(); // PopFront() - 取出最早进入的
-        //     if (!tube)
-        //     {
-        //         spdlog::warn("Back buffer is empty, no tube to move to basket");
-        //     }
-        //     else if (!ctx.basket.Push(std::move(tube))) // PushBack() - 追加到末尾
-        //     {
-        //         spdlog::error("Failed to push tube from back buffer to basket");
-        //     }
-        //     else
-        //     {
-        //         ctx.basket.DebugOut();
-        //     }
-        // }
-
         auto tube = ctx.backBuffer.Pop(); // PopFront() - 取出最早进入的
+
         if (!tube)
         {
             spdlog::warn("Back buffer is empty, no tube to move to basket");
@@ -457,30 +374,7 @@ void handleMoveTubeCmd(TubeTrackContext &ctx, const char *value)
     }
     else if (cmd.from == "basket" && cmd.to == "backbuffer") // 反向：打包区 -> 缓冲区（后进先出）
     {
-        // 缓冲区是多管子的，直接推送即可，无需判断是否有管子
-        // 判断打包区是否有管子
-        // if (ctx.basket.IsEmpty())
-        // {
-        //     spdlog::warn("Basket is empty, no tube to move to back buffer");
-        //     return;
-        // }
-        // else
-        // {
-        //     auto tube = ctx.basket.PopBack(); // PopBack() - 取出最后进入的
 
-        //     if (!tube)
-        //     {
-        //         spdlog::warn("Basket is empty, no tube to move to back buffer");
-        //     }
-        //     else if (!ctx.backBuffer.PushFront(std::move(tube))) //  PushFront() - 插入到最前面
-        //     {
-        //         spdlog::error("Failed to push tube from basket to back buffer");
-        //     }
-        //     else
-        //     {
-        //         ctx.backBuffer.DebugOut();
-        //     }
-        // }
         auto tube = ctx.basket.PopBack(); // PopBack() - 取出最后进入的
         if (!tube)
         {
@@ -590,17 +484,14 @@ void handleDeleteTubeCmd(TubeTrackContext &ctx, const char *value)
     else if (cmd.position_name == "backbuffer")
     {
         position = &ctx.backBuffer;
-        // isMultiPosition = true;
     }
     else if (cmd.position_name == "scrapt")
     {
         position = &ctx.scrapt;
-        // isMultiPosition = true;
     }
     else if (cmd.position_name == "basket")
     {
         position = &ctx.basket;
-        // isMultiPosition = true;
     }
 
     if (!position)
@@ -608,18 +499,6 @@ void handleDeleteTubeCmd(TubeTrackContext &ctx, const char *value)
         spdlog::warn("Unsupported DELETE_TUBE_CMD position: {}", cmd.position_name.c_str());
         return;
     }
-
-    // if (!isMultiPosition && cmd.seq_no != 0)
-    // {
-    //     spdlog::warn("Single-tube position only supports seq_no=0 for DELETE_TUBE_CMD: position={}, seq_no={}", cmd.position_name.c_str(), cmd.seq_no);
-    //     return;
-    // }
-
-    // if (!position->Delete(cmd.seq_no))
-    // {
-    //     spdlog::warn("Tube not found for DELETE_TUBE_CMD: position={}, seq_no={}", cmd.position_name.c_str(), cmd.seq_no);
-    //     return;
-    // }
 
     position->Delete(cmd.seq_no);
 
@@ -641,11 +520,6 @@ void handleSetCurrentContractCmd(TubeTrackContext &ctx, const char *value)
         return;
     }
 
-    // if (!ctx.prodPlan.ApplyCurrentContract(orderNo, itemNo))
-    // {
-    //     spdlog::warn("SET_CURRENT_CONTRACT_CMD failed for order_no={}, item_no={}", orderNo, itemNo);
-    // }
-
     ctx.prodPlan.ApplyCurrentContract(orderNo, itemNo);
 }
 
@@ -659,25 +533,6 @@ void handleAddTubeCmd(TubeTrackContext &ctx, const char *value)
     if (cmd.position_name == "backbuffer")
     {
         auto tube = std::make_unique<CTube>();
-
-        // // //模拟插入管子的数据
-        // tube->calib_tube = false;                    // 不是样管
-        // tube->order_no = "G2A0000000";               // 合同号
-        // tube->item_no = "0";                          // 项目号
-        // tube->roll_no = "W21250";                    // 轧批号
-        // tube->melt_no = "12345678";                  // 炉号
-        // tube->lot_no = "123456";                     // 试批号
-        // tube->lotno_coupling = "123456";              // 接箍批号
-        // tube->meltno_coupling = "12345679";          // 接箍炉号
-        // static int s_nextTubeNo = 123466;            // 静态变量，每次调用自增
-        // tube->tube_no = s_nextTubeNo++;              // 管号（自增）
-        // static int s_nextFlowNo = 1;                 // 流水号自增
-        // tube->flow_no = s_nextFlowNo++;              // 使用自增流水号
-        // tube->length = 100.0;                         // 长度（米）
-        // tube->weight = 0.0;                           // 重量（KG）
-        // tube->length_ok = true;                       // 长度合格
-        // tube->weight_ok = true;                       // 重量合格
-        // tube->sprayed = false;                        // 是否喷印过
 
         // 查找pg数据库，获取管子数据，填充到tube对象中
         pqxx::nontransaction ntx(*ctx.pgConn);
@@ -709,11 +564,6 @@ void handleAddTubeCmd(TubeTrackContext &ctx, const char *value)
             tube->weight = 0.0; // 重量（KG）
         }
 
-        // if (!ctx.backBuffer.PushAt(std::move(tube), cmd.seq_no))
-        // {
-        //     spdlog::error("Failed to push tube into back buffer at insert position {}", cmd.seq_no);
-        //     return;
-        // }
         ctx.backBuffer.PushAt(std::move(tube), cmd.seq_no);
         ctx.backBuffer.DebugOut();
     }
@@ -751,11 +601,6 @@ void handleAddTubeCmd(TubeTrackContext &ctx, const char *value)
             tube->weight = 0.0; // 重量（KG）
         }
 
-        // if (!ctx.basket.PushAt(std::move(tube), cmd.seq_no))
-        // {
-        //     spdlog::error("Failed to push tube into basket at insert position {}", cmd.seq_no);
-        //     return;
-        // }
         ctx.basket.PushAt(std::move(tube), cmd.seq_no);
         ctx.basket.DebugOut();
     }
@@ -779,16 +624,6 @@ void moveTubeToWbase(TubeTrackContext &ctx)
     auto tube3 = ctx.carvePos.Pop();
     auto tube4 = ctx.sprayPos.Pop();
     auto tube5 = ctx.circlePos.Pop();
-
-    // if (ctx.walkingBeam.Push(std::move(tube1), std::move(tube2), std::move(tube3), std::move(tube4), std::move(tube5)))
-    // {
-    //     spdlog::info("Moved tubes to walking beam");
-    //     ctx.walkingBeam.DebugOut();
-    // }
-    // else
-    // {
-    //     spdlog::error("Failed to move tubes to walking beam");
-    // }
 
     ctx.walkingBeam.Push(std::move(tube1), std::move(tube2), std::move(tube3), std::move(tube4), std::move(tube5));
     ctx.walkingBeam.DebugOut();
@@ -836,19 +671,6 @@ void handleAlignPosOn(TubeTrackContext &ctx, const char *value)
 
         ctx.alignPos.Push(std::move(tube));
         ctx.alignPos.DebugOut();
-
-        // if (tube && ctx.alignPos.Push(std::move(tube)))
-        // {
-        //     ctx.alignPos.DebugOut();
-        // }
-        // else if (!tube)
-        // {
-        //     spdlog::warn("Production plan is empty, no tube to move to align position");
-        // }
-        // else
-        // {
-        //     spdlog::error("Failed to push tube into align position");
-        // }
 
         // 从步进梁弹出管子，推送到称重、刻印、喷印、色环，出废辊道工位
         moveTubeToPosion(ctx);
@@ -980,18 +802,6 @@ void handleScrRollerOn(TubeTrackContext &ctx, const char *value)
             ctx.scrapt.DebugOut();
         }
 
-        // if (tube && ctx.backBuffer.Push(std::move(tube)))
-        // {
-        //     ctx.backBuffer.DebugOut();
-        // }
-        // else if (!tube)
-        // {
-        //     spdlog::warn("Scrap roller is empty, no tube to move to back buffer");
-        // }
-        // else
-        // {
-        //     spdlog::error("Failed to push tube into back buffer");
-        // }
     }
     else
     {
@@ -1013,74 +823,3 @@ void handleWbBase(TubeTrackContext &ctx, const char *value)
 
     ctx.walkingBeam.SetAtBase(isOn);
 }
-
-// // 初始化生产计划数据
-// ctx.prodPlan.order_no = "20240001";
-// ctx.prodPlan.item_no = "ITEM001";
-// ctx.prodPlan.roll_no = "ROLL1234";
-// ctx.prodPlan.melt_no = "MELT5678";
-// ctx.prodPlan.lot_no = "LOT91011";
-// ctx.prodPlan.lotno_coupling = "COUPLELOT";
-// ctx.prodPlan.meltno_coupling = "COUPLEMELT";
-// ctx.prodPlan.feed_num = 100;  // 初始投料支数
-// ctx.prodPlan.tube_no = 0;     // 初始管号
-
-// // 初始同步到Redis
-// ctx.prodPlan.UpdateForm();
-
-// // 模拟生产流程
-// for (int i = 0; i < 100 && g_running; i++)
-// {
-//     // 从投料计划中获取管子数据
-//     auto tube = ctx.prodPlan.Pop();
-//     if (tube)
-//     {
-//         // 将管子数据推送到测长工位
-//         if (ctx.lengthPos.Push(std::move(tube)))
-//         {
-//             // 成功推送后，输出工位状态
-//             ctx.lengthPos.DebugOut();
-
-//             // 从测长工位弹出管子数据
-//             tube = ctx.lengthPos.Pop();
-//         }
-
-//         // 更新Redis数据
-//         ctx.prodPlan.UpdateForm();
-//     }
-
-//     sleep(1); // 模拟生产节奏
-// }
-
-// else if (cmd.from == "scrapt" && cmd.to == "basket") // 从废料辊道移动到篮子
-// {
-//     // 判断篮子是否有管子，如果没有再从废料辊道弹出
-//     if (ctx.basket.IsEmpty())
-//     {
-//         // 判断废料辊道是否有管子，如果有再推送到篮子
-//         if (!ctx.scraptRoller.IsEmpty())
-//         {
-//             auto tube = ctx.scraptRoller.Pop();
-//             if (tube && ctx.basket.Push(std::move(tube)))
-//             {
-//                 ctx.basket.DebugOut();
-//             }
-//             else if (!tube)
-//             {
-//                 spdlog::warn("Scrapt roller is empty, no tube to move to basket");
-//             }
-//             else
-//             {
-//                 spdlog::error("Failed to push tube into basket");
-//             }
-//         }
-//         else
-//         {
-//             spdlog::warn("Scrapt roller is empty, no tube to move to basket");
-//         }
-//     }
-//     else
-//     {
-//         spdlog::warn("Basket is not empty, cannot move tube from scrapt roller");
-//     }
-// }

--- a/TubeTrack/src/workthread.cpp
+++ b/TubeTrack/src/workthread.cpp
@@ -424,23 +424,27 @@ void handleMoveTubeCmd(TubeTrackContext &ctx, const char *value)
     {
         // 打包区是多管子的，直接推送即可，无需判断是否有管子
         // 判断缓冲区是否有管子
-        if (ctx.backBuffer.IsEmpty())
-        {
-            spdlog::warn("Back buffer is empty, no tube to move to basket");
-            return;
-        }
-        else
-        {
-
-            else if (!ctx.basket.Push(std::move(tube))) // PushBack() - 追加到末尾
-            {
-                spdlog::error("Failed to push tube from back buffer to basket");
-            }
-            else
-            {
-                ctx.basket.DebugOut();
-            }
-        }
+        // if (ctx.backBuffer.IsEmpty())
+        // {
+        //     spdlog::warn("Back buffer is empty, no tube to move to basket");
+        //     return;
+        // }
+        // else
+        // {
+        //     auto tube = ctx.backBuffer.Pop(); // PopFront() - 取出最早进入的
+        //     if (!tube)
+        //     {
+        //         spdlog::warn("Back buffer is empty, no tube to move to basket");
+        //     }
+        //     else if (!ctx.basket.Push(std::move(tube))) // PushBack() - 追加到末尾
+        //     {
+        //         spdlog::error("Failed to push tube from back buffer to basket");
+        //     }
+        //     else
+        //     {
+        //         ctx.basket.DebugOut();
+        //     }
+        // }
 
         auto tube = ctx.backBuffer.Pop(); // PopFront() - 取出最早进入的
         if (!tube)

--- a/TubeTrack/src/workthread.cpp
+++ b/TubeTrack/src/workthread.cpp
@@ -258,8 +258,9 @@ void workThread(TubeTrackContext &ctx)
         }
         catch (const std::exception &ex)
         {
-            // 打印tagname和错误信息，继续循环
-            std::cerr << "Error processing tag: " << tagname << ", error: " << ex.what() << std::endl;
+            // std::cerr << "Error processing tag: " << tagname << ", error: " << ex.what() << std::endl;
+            spdlog::error("Error processing tag: {}, error: {}", tagname, ex.what());
+            throw; // 继续抛出异常，交由上层处理（可能导致线程退出）
         }
         //.....
     }
@@ -275,29 +276,31 @@ void handleMoveTubeCmd(TubeTrackContext &ctx, const char *value)
     {
         if (!ctx.alignPos.IsEmpty())
         {
-            spdlog::warn("Align position is not empty, cannot move tube from Production plan");
+            spdlog::warn("Align position is not empty, cannot move tube to Align position");
             return;
         }
 
-        if (ctx.prodPlan.IsEmpty())
-        {
-            spdlog::warn("Production plan is empty, no tube to move to Align position");
-            return;
-        }
+        // 和Pop逻辑上重复
+        // if (ctx.prodPlan.IsEmpty())
+        // {
+        //     spdlog::warn("Production plan is empty, no tube to move to Align position");
+        //     return;
+        // }
 
         auto tube = ctx.prodPlan.Pop();
         if (!tube)
         {
-            spdlog::warn("Production plan returned no tube, cannot move to Align position");
+            spdlog::warn("Production plan returned no tube, cannot move tube to Align position");
             return;
         }
 
-        if (!ctx.alignPos.Push(std::move(tube)))
-        {
-            spdlog::error("Failed to push tube from Production plan to Align position");
-            return;
-        }
+        // if (!ctx.alignPos.Push(std::move(tube)))
+        // {
+        //     spdlog::error("Failed to push tube from Production plan to Align position");
+        //     return;
+        // }
 
+        ctx.alignPos.Push(std::move(tube));
         ctx.alignPos.DebugOut();
     }
     else if (cmd.from == "align" && cmd.to == "plan") // 反向：对齐工位 -> 生产计划
@@ -348,27 +351,38 @@ void handleMoveTubeCmd(TubeTrackContext &ctx, const char *value)
     {
         // 缓冲区是多管子的，直接推送即可，无需判断是否有管子
         // 判断废料辊道是否有管子
-        if (ctx.scraptRoller.IsEmpty())
+        // if (ctx.scraptRoller.IsEmpty())
+        // {
+        //     spdlog::warn("Scrapt roller is empty, no tube to move to back buffer");
+        //     return;
+        // }
+        // else
+        // {
+        //     auto tube = ctx.scraptRoller.Pop();
+
+        //     if (!tube)
+        //     {
+        //         spdlog::warn("Scrapt roller is empty, no tube to move to back buffer");
+        //         return;
+        //     }
+        //     else if (!ctx.backBuffer.Push(std::move(tube)))
+        //     {
+        //         spdlog::error("Failed to push tube from Scrapt roller to back buffer");
+        //     }
+        //     else
+        //     {
+        //         ctx.backBuffer.DebugOut();
+        //     }
+        // }
+        auto tube = ctx.scraptRoller.Pop();
+
+        if (!tube)
         {
             spdlog::warn("Scrapt roller is empty, no tube to move to back buffer");
             return;
         }
-        else
-        {
-            auto tube = ctx.scraptRoller.Pop();
-            if (!tube)
-            {
-                spdlog::warn("Scrapt roller is empty, no tube to move to back buffer");
-            }
-            else if (!ctx.backBuffer.Push(std::move(tube)))
-            {
-                spdlog::error("Failed to push tube from Scrapt roller to back buffer");
-            }
-            else
-            {
-                ctx.backBuffer.DebugOut();
-            }
-        }
+        ctx.backBuffer.Push(std::move(tube));
+        ctx.backBuffer.DebugOut();
     }
     // 问题在上游发出的 MOVE_TUBE_CMD 参数不包含这个命令，暂时注释掉
     // （需要修正 gPlat 或命令发送端，把 scaptroller 改成 scraptroller）
@@ -381,27 +395,30 @@ void handleMoveTubeCmd(TubeTrackContext &ctx, const char *value)
     {
         // 废料筐是多管子的，直接推送即可，无需判断是否有管子
         // 判断废料辊道是否有管子
-        if (ctx.scraptRoller.IsEmpty())
+        // if (ctx.scraptRoller.IsEmpty())
+        // {
+        //     spdlog::warn("Scrapt roller is empty, no tube to move to scrapt");
+        //     return;
+        // }
+        // else
+        // {
+        //     else if (!ctx.scrapt.Push(std::move(tube)))
+        //     {
+        //         spdlog::error("Failed to push tube from Scrapt roller to scrapt");
+        //     }
+        //     else
+        //     {
+        //         ctx.scrapt.DebugOut();
+        //     }
+        // }
+        auto tube = ctx.scraptRoller.Pop();
+        if (!tube)
         {
             spdlog::warn("Scrapt roller is empty, no tube to move to scrapt");
             return;
         }
-        else
-        {
-            auto tube = ctx.scraptRoller.Pop();
-            if (!tube)
-            {
-                spdlog::warn("Scrapt roller is empty, no tube to move to scrapt");
-            }
-            else if (!ctx.scrapt.Push(std::move(tube)))
-            {
-                spdlog::error("Failed to push tube from Scrapt roller to scrapt");
-            }
-            else
-            {
-                ctx.scrapt.DebugOut();
-            }
-        }
+        ctx.scrapt.Push(std::move(tube));
+        ctx.scrapt.DebugOut();
     }
     else if (cmd.from == "backbuffer" && cmd.to == "basket") // 缓冲区 -> 打包区(先进先出)
     {
@@ -414,11 +431,7 @@ void handleMoveTubeCmd(TubeTrackContext &ctx, const char *value)
         }
         else
         {
-            auto tube = ctx.backBuffer.Pop(); // PopFront() - 取出最早进入的
-            if (!tube)
-            {
-                spdlog::warn("Back buffer is empty, no tube to move to basket");
-            }
+
             else if (!ctx.basket.Push(std::move(tube))) // PushBack() - 追加到末尾
             {
                 spdlog::error("Failed to push tube from back buffer to basket");
@@ -428,32 +441,50 @@ void handleMoveTubeCmd(TubeTrackContext &ctx, const char *value)
                 ctx.basket.DebugOut();
             }
         }
+
+        auto tube = ctx.backBuffer.Pop(); // PopFront() - 取出最早进入的
+        if (!tube)
+        {
+            spdlog::warn("Back buffer is empty, no tube to move to basket");
+            return;
+        }
+        ctx.basket.Push(std::move(tube));
+        ctx.basket.DebugOut();
     }
     else if (cmd.from == "basket" && cmd.to == "backbuffer") // 反向：打包区 -> 缓冲区（后进先出）
     {
         // 缓冲区是多管子的，直接推送即可，无需判断是否有管子
         // 判断打包区是否有管子
-        if (ctx.basket.IsEmpty())
+        // if (ctx.basket.IsEmpty())
+        // {
+        //     spdlog::warn("Basket is empty, no tube to move to back buffer");
+        //     return;
+        // }
+        // else
+        // {
+        //     auto tube = ctx.basket.PopBack(); // PopBack() - 取出最后进入的
+
+        //     if (!tube)
+        //     {
+        //         spdlog::warn("Basket is empty, no tube to move to back buffer");
+        //     }
+        //     else if (!ctx.backBuffer.PushFront(std::move(tube))) //  PushFront() - 插入到最前面
+        //     {
+        //         spdlog::error("Failed to push tube from basket to back buffer");
+        //     }
+        //     else
+        //     {
+        //         ctx.backBuffer.DebugOut();
+        //     }
+        // }
+        auto tube = ctx.basket.PopBack(); // PopBack() - 取出最后进入的
+        if (!tube)
         {
             spdlog::warn("Basket is empty, no tube to move to back buffer");
             return;
         }
-        else
-        {
-            auto tube = ctx.basket.PopBack(); // PopBack() - 取出最后进入的
-            if (!tube)
-            {
-                spdlog::warn("Basket is empty, no tube to move to back buffer");
-            }
-            else if (!ctx.backBuffer.PushFront(std::move(tube))) //  PushFront() - 插入到最前面
-            {
-                spdlog::error("Failed to push tube from basket to back buffer");
-            }
-            else
-            {
-                ctx.backBuffer.DebugOut();
-            }
-        }
+        ctx.backBuffer.PushFront(std::move(tube));
+        ctx.backBuffer.DebugOut();
     }
     else
     {
@@ -527,7 +558,7 @@ void handleDeleteTubeCmd(TubeTrackContext &ctx, const char *value)
     spdlog::info("Handling DELETE_TUBE_CMD: position={}, seq_no={}", cmd.position_name.c_str(), cmd.seq_no);
 
     CPositionBase *position = nullptr;
-    bool isMultiPosition = false;
+    // bool isMultiPosition = false;
     if (cmd.position_name == "align")
     {
         position = &ctx.alignPos;
@@ -555,17 +586,17 @@ void handleDeleteTubeCmd(TubeTrackContext &ctx, const char *value)
     else if (cmd.position_name == "backbuffer")
     {
         position = &ctx.backBuffer;
-        isMultiPosition = true;
+        // isMultiPosition = true;
     }
     else if (cmd.position_name == "scrapt")
     {
         position = &ctx.scrapt;
-        isMultiPosition = true;
+        // isMultiPosition = true;
     }
     else if (cmd.position_name == "basket")
     {
         position = &ctx.basket;
-        isMultiPosition = true;
+        // isMultiPosition = true;
     }
 
     if (!position)
@@ -574,17 +605,19 @@ void handleDeleteTubeCmd(TubeTrackContext &ctx, const char *value)
         return;
     }
 
-    if (!isMultiPosition && cmd.seq_no != 0)
-    {
-        spdlog::warn("Single-tube position only supports seq_no=0 for DELETE_TUBE_CMD: position={}, seq_no={}", cmd.position_name.c_str(), cmd.seq_no);
-        return;
-    }
+    // if (!isMultiPosition && cmd.seq_no != 0)
+    // {
+    //     spdlog::warn("Single-tube position only supports seq_no=0 for DELETE_TUBE_CMD: position={}, seq_no={}", cmd.position_name.c_str(), cmd.seq_no);
+    //     return;
+    // }
 
-    if (!position->Delete(cmd.seq_no))
-    {
-        spdlog::warn("Tube not found for DELETE_TUBE_CMD: position={}, seq_no={}", cmd.position_name.c_str(), cmd.seq_no);
-        return;
-    }
+    // if (!position->Delete(cmd.seq_no))
+    // {
+    //     spdlog::warn("Tube not found for DELETE_TUBE_CMD: position={}, seq_no={}", cmd.position_name.c_str(), cmd.seq_no);
+    //     return;
+    // }
+
+    position->Delete(cmd.seq_no);
 
     position->DebugOut();
 }
@@ -604,10 +637,12 @@ void handleSetCurrentContractCmd(TubeTrackContext &ctx, const char *value)
         return;
     }
 
-    if (!ctx.prodPlan.ApplyCurrentContract(orderNo, itemNo))
-    {
-        spdlog::warn("SET_CURRENT_CONTRACT_CMD failed for order_no={}, item_no={}", orderNo, itemNo);
-    }
+    // if (!ctx.prodPlan.ApplyCurrentContract(orderNo, itemNo))
+    // {
+    //     spdlog::warn("SET_CURRENT_CONTRACT_CMD failed for order_no={}, item_no={}", orderNo, itemNo);
+    // }
+
+    ctx.prodPlan.ApplyCurrentContract(orderNo, itemNo);
 }
 
 // -----------处理添加管子命令----------
@@ -670,11 +705,12 @@ void handleAddTubeCmd(TubeTrackContext &ctx, const char *value)
             tube->weight = 0.0; // 重量（KG）
         }
 
-        if (!ctx.backBuffer.PushAt(std::move(tube), cmd.seq_no))
-        {
-            spdlog::error("Failed to push tube into back buffer at insert position {}", cmd.seq_no);
-            return;
-        }
+        // if (!ctx.backBuffer.PushAt(std::move(tube), cmd.seq_no))
+        // {
+        //     spdlog::error("Failed to push tube into back buffer at insert position {}", cmd.seq_no);
+        //     return;
+        // }
+        ctx.backBuffer.PushAt(std::move(tube), cmd.seq_no);
         ctx.backBuffer.DebugOut();
     }
     else if (cmd.position_name == "basket")
@@ -711,11 +747,12 @@ void handleAddTubeCmd(TubeTrackContext &ctx, const char *value)
             tube->weight = 0.0; // 重量（KG）
         }
 
-        if (!ctx.basket.PushAt(std::move(tube), cmd.seq_no))
-        {
-            spdlog::error("Failed to push tube into basket at insert position {}", cmd.seq_no);
-            return;
-        }
+        // if (!ctx.basket.PushAt(std::move(tube), cmd.seq_no))
+        // {
+        //     spdlog::error("Failed to push tube into basket at insert position {}", cmd.seq_no);
+        //     return;
+        // }
+        ctx.basket.PushAt(std::move(tube), cmd.seq_no);
         ctx.basket.DebugOut();
     }
     else
@@ -739,15 +776,18 @@ void moveTubeToWbase(TubeTrackContext &ctx)
     auto tube4 = ctx.sprayPos.Pop();
     auto tube5 = ctx.circlePos.Pop();
 
-    if (ctx.walkingBeam.Push(std::move(tube1), std::move(tube2), std::move(tube3), std::move(tube4), std::move(tube5)))
-    {
-        spdlog::info("Moved tubes to walking beam");
-        ctx.walkingBeam.DebugOut();
-    }
-    else
-    {
-        spdlog::error("Failed to move tubes to walking beam");
-    }
+    // if (ctx.walkingBeam.Push(std::move(tube1), std::move(tube2), std::move(tube3), std::move(tube4), std::move(tube5)))
+    // {
+    //     spdlog::info("Moved tubes to walking beam");
+    //     ctx.walkingBeam.DebugOut();
+    // }
+    // else
+    // {
+    //     spdlog::error("Failed to move tubes to walking beam");
+    // }
+
+    ctx.walkingBeam.Push(std::move(tube1), std::move(tube2), std::move(tube3), std::move(tube4), std::move(tube5));
+    ctx.walkingBeam.DebugOut();
 }
 
 //--------从步进梁弹出管子，推送到对齐、称重、刻印、喷印、色环工位--------
@@ -777,18 +817,34 @@ void handleAlignPosOn(TubeTrackContext &ctx, const char *value)
     {
         // 执行对齐工位有料状态的相关操作
         auto tube = ctx.prodPlan.Pop();
-        if (tube && ctx.alignPos.Push(std::move(tube)))
-        {
-            ctx.alignPos.DebugOut();
-        }
-        else if (!tube)
+
+        if (!tube)
         {
             spdlog::warn("Production plan is empty, no tube to move to align position");
+            return;
         }
-        else
+
+        if (!ctx.alignPos.IsEmpty())
         {
-            spdlog::error("Failed to push tube into align position");
+            spdlog::warn("Align position is not empty, cannot move tube from Production plan");
+            return;
         }
+
+        ctx.alignPos.Push(std::move(tube));
+        ctx.alignPos.DebugOut();
+
+        // if (tube && ctx.alignPos.Push(std::move(tube)))
+        // {
+        //     ctx.alignPos.DebugOut();
+        // }
+        // else if (!tube)
+        // {
+        //     spdlog::warn("Production plan is empty, no tube to move to align position");
+        // }
+        // else
+        // {
+        //     spdlog::error("Failed to push tube into align position");
+        // }
 
         // 从步进梁弹出管子，推送到称重、刻印、喷印、色环，出废辊道工位
         moveTubeToPosion(ctx);
@@ -902,18 +958,36 @@ void handleScrRollerOn(TubeTrackContext &ctx, const char *value)
     {
         // 从废料辊道弹出管子，推送到缓冲区
         auto tube = ctx.scraptRoller.Pop();
-        if (tube && ctx.backBuffer.Push(std::move(tube)))
-        {
-            ctx.backBuffer.DebugOut();
-        }
-        else if (!tube)
+
+        if (!tube)
         {
             spdlog::warn("Scrap roller is empty, no tube to move to back buffer");
+            return;
+        }
+
+        if (tube->weight_ok && tube->length_ok)
+        {
+            ctx.backBuffer.Push(std::move(tube));
+            ctx.backBuffer.DebugOut();
         }
         else
         {
-            spdlog::error("Failed to push tube into back buffer");
+            ctx.scrapt.Push(std::move(tube));
+            ctx.scrapt.DebugOut();
         }
+
+        // if (tube && ctx.backBuffer.Push(std::move(tube)))
+        // {
+        //     ctx.backBuffer.DebugOut();
+        // }
+        // else if (!tube)
+        // {
+        //     spdlog::warn("Scrap roller is empty, no tube to move to back buffer");
+        // }
+        // else
+        // {
+        //     spdlog::error("Failed to push tube into back buffer");
+        // }
     }
     else
     {


### PR DESCRIPTION
- Updated CAlignPosition, CBackBuffer, CBasket, CCarvePosition, CCirclePosition, CSprayPosition, CScrapt, CScraptRoller, and CWeightPosition classes to initialize with Redis key and position name.
- Removed hardcoded Redis key definitions from class members.
- Modified UpdateForm methods in respective classes to use the new member variables for Redis key.
- Updated CPositionBase to handle Redis interactions and added RestoreFromRedis method.
- Refactored CProductionPlan to include Redis key and position name, and updated RestoreFromRedis method.
- Adjusted context initialization in TubeTrackContext to pass Redis key and position name to each position class.

Co-authored-by: Copilot <copilot@github.com>